### PR TITLE
fix travis build by reordering the repositories

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
 }
 
 repositories {
-    maven("https://raw.github.com/lovelysystems/maven/master/releases")
     mavenCentral()
+    maven("https://raw.github.com/lovelysystems/maven/master/releases")
 }
 
 dependencies {


### PR DESCRIPTION
looks like travis is not able to download from our github maven rep since there is a race condition in openjdk 11.0.2 used by travis
see also https://newbedev.com/javax-net-ssl-sslexception-no-psk-available-unable-to-resume